### PR TITLE
setting mp worker spawn method

### DIFF
--- a/src/aind_hcr_data_transformation/compress/czi_to_zarr.py
+++ b/src/aind_hcr_data_transformation/compress/czi_to_zarr.py
@@ -82,6 +82,7 @@ def create_spec(
 
     if cpu_cnt is None:
         cpu_cnt = multiprocessing.cpu_count()
+    multiprocessing.set_start_method("spawn", force=True)
 
     zyx_resolution = [
         f"{r}um" if r is not None else None for r in zyx_resolution
@@ -218,6 +219,7 @@ async def create_downsample_dataset(
     if cpu_cnt is None:
         cpu_cnt = multiprocessing.cpu_count()
 
+    multiprocessing.set_start_method("spawn", force=True)
     kvstore_dict = {
         "driver": "file",
     }
@@ -379,6 +381,7 @@ def czi_stack_zarr_writer(
     """
     output_path = f"{output_path}/{stack_name}"
     start_time = time.time()
+    multiprocessing.set_start_method("spawn", force=True)
 
     with czifile.CziFile(str(czi_path)) as czi:
         dataset_shape = tuple(i for i in czi.shape if i != 1)

--- a/src/aind_hcr_data_transformation/compress/czi_to_zarr.py
+++ b/src/aind_hcr_data_transformation/compress/czi_to_zarr.py
@@ -82,7 +82,6 @@ def create_spec(
 
     if cpu_cnt is None:
         cpu_cnt = multiprocessing.cpu_count()
-    multiprocessing.set_start_method("spawn", force=True)
 
     zyx_resolution = [
         f"{r}um" if r is not None else None for r in zyx_resolution
@@ -219,7 +218,6 @@ async def create_downsample_dataset(
     if cpu_cnt is None:
         cpu_cnt = multiprocessing.cpu_count()
 
-    multiprocessing.set_start_method("spawn", force=True)
     kvstore_dict = {
         "driver": "file",
     }
@@ -381,7 +379,6 @@ def czi_stack_zarr_writer(
     """
     output_path = f"{output_path}/{stack_name}"
     start_time = time.time()
-    multiprocessing.set_start_method("spawn", force=True)
 
     with czifile.CziFile(str(czi_path)) as czi:
         dataset_shape = tuple(i for i in czi.shape if i != 1)

--- a/src/aind_hcr_data_transformation/zeiss_job.py
+++ b/src/aind_hcr_data_transformation/zeiss_job.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from time import time
 from typing import Any, Dict, List
 from urllib.parse import urlparse
+import multiprocessing
 
 from aind_data_transformation.core import GenericEtl, JobResponse, get_parser
 from packaging import version
@@ -273,4 +274,6 @@ def job_entrypoint(sys_args: list):
 
 
 if __name__ == "__main__":
+    multiprocessing.set_start_method("spawn", force=True)
     job_entrypoint(sys.argv[1:])
+    


### PR DESCRIPTION
Force multiprocessing worker spawn method to avoid known issue in tensorstore according to: https://github.com/google/tensorstore/issues/206. 
