### PR TITLE
Feat transactions

### DIFF
--- a/src/aind_hcr_data_transformation/compress/czi_to_zarr_s3.py
+++ b/src/aind_hcr_data_transformation/compress/czi_to_zarr_s3.py
@@ -25,16 +25,16 @@ from aind_hcr_data_transformation.utils.utils import (
 
 
 def create_spec(
-        output_path: str,
-        data_shape: list,
-        data_dtype: str,
-        shard_shape: list,
-        chunk_shape: list,
-        zyx_resolution: list,
-        compressor_kwargs: dict,
-        bucket_name,
-        scale: str = "0",
-        aws_region: str = "us-west-2",
+    output_path: str,
+    data_shape: list,
+    data_dtype: str,
+    shard_shape: list,
+    chunk_shape: list,
+    zyx_resolution: list,
+    compressor_kwargs: dict,
+   bucket_name: str = None,
+    scale: str = "0",
+    aws_region: str = "us-west-2",
 ) -> dict:
     """
     Create a TensorStore Zarr v3 specification for writing
@@ -81,7 +81,7 @@ def create_spec(
             "bucket": bucket_name,
             "aws_region": aws_region,
             "path": output_path,
-            "aws_credentials": {"type": "default"}
+            "aws_credentials": {"type": "default"},
         },
         "path": str(scale),
         "recheck_cached_metadata": False,
@@ -137,13 +137,13 @@ def create_spec(
 
 
 def create_downsample_dataset(
-        dataset_path: str,
-        start_scale: int,
-        downsample_factor: list,
-        downsample_mode: str,
-        compressor_kwargs: dict,
-        bucket_name: str,
-        aws_region: str = "us-west-2",
+    dataset_path: str,
+    start_scale: int,
+    downsample_factor: list,
+    downsample_mode: str,
+    compressor_kwargs: dict,
+    bucket_name: str,
+    aws_region: str = "us-west-2",
 ):
     """
     Create a new downsampled scale level in a multi-scale Zarr v3 dataset.
@@ -224,22 +224,24 @@ def create_downsample_dataset(
     down_dataset = ts.open(down_spec).result()
     downsampled_data = downsampled_dataset.read().result()
     with ts.Transaction() as transaction:
-        down_dataset.with_transaction(transaction).write(downsampled_data).result()
+        down_dataset.with_transaction(transaction).write(
+            downsampled_data
+        ).result()
 
 
 def czi_stack_zarr_writer(
-        czi_path: str,
-        output_path: str,
-        voxel_size: List[float],
-        shard_size: List[int],
-        chunk_size: List[int],
-        scale_factor: List[int],
-        n_lvls: int,
-        channel_name: str,
-        stack_name: str,
-        compressor_kwargs: dict,
-        bucket_name: str,
-        downsample_mode: Optional[str] = "mean",
+    czi_path: str,
+    output_path: str,
+    voxel_size: List[float],
+    shard_size: List[int],
+    chunk_size: List[int],
+    scale_factor: List[int],
+    n_lvls: int,
+    channel_name: str,
+    stack_name: str,
+    compressor_kwargs: dict,
+    bucket_name: str,
+    downsample_mode: Optional[str] = "mean",
 ):
     """
     Writes a fused Zeiss channel in OMEZarr
@@ -371,9 +373,9 @@ def czi_stack_zarr_writer(
         # shard size must be TCZYX order
         block_count = 0
         for block, axis_area in czi_block_generator(
-                czi,
-                axis_jumps=shard_size[-3],
-                slice_axis="z",
+            czi,
+            axis_jumps=shard_size[-3],
+            slice_axis="z",
         ):
             region = (
                 slice(None),
@@ -383,12 +385,18 @@ def czi_stack_zarr_writer(
                 slice(0, dataset_shape[-1]),
             )
             try:
-                with ts.Transaction() as transaction: 
-                    dataset[region].with_transaction(transaction).write(pad_array_n_d(block)).result()
+                with ts.Transaction() as transaction:
+                    dataset[region].with_transaction(transaction).write(
+                        pad_array_n_d(block)
+                    ).result()
                 block_count += 1
-                logging.info(f"Completed block {block_count} write for z-slices {axis_area}")
+                logging.info(
+                    f"Completed block {block_count} write for z-slices {axis_area}"
+                )
             except Exception as e:
-                logging.error(f"Failed to write block {block_count} for z-slices {axis_area}: {e}")
+                logging.error(
+                    f"Failed to write block {block_count} for z-slices {axis_area}: {e}"
+                )
                 continue
             # dataset[region].write(pad_array_n_d(block)).result()
 

--- a/src/aind_hcr_data_transformation/compress/czi_to_zarr_s3.py
+++ b/src/aind_hcr_data_transformation/compress/czi_to_zarr_s3.py
@@ -222,11 +222,14 @@ def create_downsample_dataset(
     )
 
     down_dataset = ts.open(down_spec).result()
-    with ts.Transaction() as transaction:
-        downsampled_data = downsampled_dataset.with_transaction(
-            transaction
-        ).read().result()
-    # downsampled_data = downsampled_dataset.read().result()
+    try:
+        with ts.Transaction() as transaction:
+            downsampled_data = downsampled_dataset.with_transaction(
+                transaction
+            ).read().result()
+    except Exception as e:
+        logging.error(f"Failed to read downsampled data: {e}")
+        raise e
     try:
         with ts.Transaction() as transaction:
             down_dataset.with_transaction(transaction).write(

--- a/src/aind_hcr_data_transformation/compress/czi_to_zarr_s3.py
+++ b/src/aind_hcr_data_transformation/compress/czi_to_zarr_s3.py
@@ -32,7 +32,7 @@ def create_spec(
     chunk_shape: list,
     zyx_resolution: list,
     compressor_kwargs: dict,
-   bucket_name: str = None,
+    bucket_name: str = None,
     scale: str = "0",
     aws_region: str = "us-west-2",
 ) -> dict:
@@ -222,7 +222,11 @@ def create_downsample_dataset(
     )
 
     down_dataset = ts.open(down_spec).result()
-    downsampled_data = downsampled_dataset.read().result()
+    with ts.Transaction() as transaction:
+        downsampled_data = downsampled_dataset.with_transaction(
+            transaction
+        ).read().result()
+    # downsampled_data = downsampled_dataset.read().result()
     with ts.Transaction() as transaction:
         down_dataset.with_transaction(transaction).write(
             downsampled_data
@@ -397,7 +401,7 @@ def czi_stack_zarr_writer(
                 logging.error(
                     f"Failed to write block {block_count} for z-slices {axis_area}: {e}"
                 )
-                continue
+                raise e
             # dataset[region].write(pad_array_n_d(block)).result()
 
         # Waiting for the tensorstore tasks

--- a/src/aind_hcr_data_transformation/compress/czi_to_zarr_s3.py
+++ b/src/aind_hcr_data_transformation/compress/czi_to_zarr_s3.py
@@ -222,7 +222,8 @@ def create_downsample_dataset(
 
     down_dataset = ts.open(down_spec).result()
     downsampled_data = downsampled_dataset.read().result()
-    down_dataset.write(downsampled_data).result()
+    with ts.Transaction() as transaction:
+        down_dataset.with_transaction(transaction).write(downsampled_data).result()
 
 
 def czi_stack_zarr_writer(
@@ -367,6 +368,7 @@ def czi_stack_zarr_writer(
         dataset = ts.open(spec).result()
 
         # shard size must be TCZYX order
+        block_count = 0
         for block, axis_area in czi_block_generator(
                 czi,
                 axis_jumps=shard_size[-3],
@@ -379,7 +381,11 @@ def czi_stack_zarr_writer(
                 slice(0, dataset_shape[-2]),
                 slice(0, dataset_shape[-1]),
             )
-            dataset[region].write(pad_array_n_d(block)).result()
+            with ts.Transaction() as transaction: 
+                dataset.with_transaction(transaction).write(pad_array_n_d(block), region=region).result()
+            block_count += 1
+            logging.info(f"Completed block {block_count} write for z-slices {axis_area}")
+            # dataset[region].write(pad_array_n_d(block)).result()
 
         # Waiting for the tensorstore tasks
         # asyncio.run(write_tasks(tasks, batch_size=batch_size))

--- a/src/aind_hcr_data_transformation/compress/czi_to_zarr_s3.py
+++ b/src/aind_hcr_data_transformation/compress/czi_to_zarr_s3.py
@@ -81,6 +81,7 @@ def create_spec(
             "bucket": bucket_name,
             "aws_region": aws_region,
             "path": output_path,
+            "aws_credentials": {"type": "default"}
         },
         "path": str(scale),
         "recheck_cached_metadata": False,
@@ -381,10 +382,14 @@ def czi_stack_zarr_writer(
                 slice(0, dataset_shape[-2]),
                 slice(0, dataset_shape[-1]),
             )
-            with ts.Transaction() as transaction: 
-                dataset[region].with_transaction(transaction).write(pad_array_n_d(block)).result()
-            block_count += 1
-            logging.info(f"Completed block {block_count} write for z-slices {axis_area}")
+            try:
+                with ts.Transaction() as transaction: 
+                    dataset[region].with_transaction(transaction).write(pad_array_n_d(block)).result()
+                block_count += 1
+                logging.info(f"Completed block {block_count} write for z-slices {axis_area}")
+            except Exception as e:
+                logging.error(f"Failed to write block {block_count} for z-slices {axis_area}: {e}")
+                continue
             # dataset[region].write(pad_array_n_d(block)).result()
 
         # Waiting for the tensorstore tasks

--- a/src/aind_hcr_data_transformation/compress/czi_to_zarr_s3.py
+++ b/src/aind_hcr_data_transformation/compress/czi_to_zarr_s3.py
@@ -382,7 +382,7 @@ def czi_stack_zarr_writer(
                 slice(0, dataset_shape[-1]),
             )
             with ts.Transaction() as transaction: 
-                dataset.with_transaction(transaction).write(pad_array_n_d(block), region=region).result()
+                dataset[region].with_transaction(transaction).write(pad_array_n_d(block)).result()
             block_count += 1
             logging.info(f"Completed block {block_count} write for z-slices {axis_area}")
             # dataset[region].write(pad_array_n_d(block)).result()

--- a/src/aind_hcr_data_transformation/compress/czi_to_zarr_s3.py
+++ b/src/aind_hcr_data_transformation/compress/czi_to_zarr_s3.py
@@ -227,11 +227,15 @@ def create_downsample_dataset(
             transaction
         ).read().result()
     # downsampled_data = downsampled_dataset.read().result()
-    with ts.Transaction() as transaction:
-        down_dataset.with_transaction(transaction).write(
-            downsampled_data
-        ).result()
-
+    try:
+        with ts.Transaction() as transaction:
+            down_dataset.with_transaction(transaction).write(
+                downsampled_data
+            ).result()
+        logging.info(f"Completed downsample scale {new_scale} write")
+    except Exception as e:
+        logging.error(f"Failed to write downsample scale {new_scale}: {e}")
+        raise e
 
 def czi_stack_zarr_writer(
     czi_path: str,

--- a/src/aind_hcr_data_transformation/zeiss_job.py
+++ b/src/aind_hcr_data_transformation/zeiss_job.py
@@ -1,13 +1,13 @@
 """Module to handle zeiss data compression"""
 
 import logging
+import multiprocessing
 import os
 import sys
 from pathlib import Path
 from time import time
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
-import multiprocessing
 
 from aind_data_transformation.core import GenericEtl, JobResponse, get_parser
 from packaging import version

--- a/src/aind_hcr_data_transformation/zeiss_job.py
+++ b/src/aind_hcr_data_transformation/zeiss_job.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from time import time
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
+import multiprocessing
 
 from aind_data_transformation.core import GenericEtl, JobResponse, get_parser
 from packaging import version
@@ -253,6 +254,8 @@ class ZeissCompressionJob(GenericEtl[ZeissJobSettings]):
 
 def job_entrypoint(sys_args: list):
     """Main function"""
+    multiprocessing.set_start_method("spawn")
+
     parser = get_parser()
     cli_args = parser.parse_args(sys_args)
     if cli_args.job_settings is not None:

--- a/tests/test_compress/test_czi_to_zarr.py
+++ b/tests/test_compress/test_czi_to_zarr.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import numpy as np
 
-from aind_hcr_data_transformation.compress.czi_to_zarr import (
+from aind_hcr_data_transformation.compress.czi_to_zarr_s3 import (
     create_downsample_dataset,
     create_spec,
     czi_stack_zarr_writer,
@@ -26,10 +26,11 @@ class TestCreateSpec(unittest.TestCase):
             chunk_shape=[1, 1, 25, 50, 75],
             zyx_resolution=[1.0, 0.5, 0.5],
             compressor_kwargs={"cname": "zstd", "clevel": 5},
+            bucket_name=None,  # Add this parameter
         )
 
         self.assertEqual(spec["driver"], "zarr3")
-        self.assertEqual(spec["kvstore"]["driver"], "file")
+        self.assertEqual(spec["kvstore"]["driver"], "s3")
         self.assertEqual(spec["kvstore"]["path"], "/test/path")
         self.assertEqual(spec["path"], "0")  # default scale
         self.assertEqual(spec["metadata"]["shape"], [1, 1, 100, 200, 300])
@@ -65,45 +66,12 @@ class TestCreateSpec(unittest.TestCase):
             compressor_kwargs={"cname": "lz4", "clevel": 3},
             bucket_name="test-bucket",
             aws_region="us-east-1",
-            cpu_cnt=8,
-            read_cache_bytes=2**31,
         )
 
         self.assertEqual(spec["kvstore"]["driver"], "s3")
         self.assertEqual(spec["kvstore"]["bucket"], "test-bucket")
         self.assertEqual(spec["kvstore"]["aws_region"], "us-east-1")
-
-        # Check context settings
-        context = spec["kvstore"]["context"]
-        self.assertEqual(context["cache_pool"]["total_bytes_limit"], 2**31)
-        self.assertEqual(context["data_copy_concurrency"]["limit"], 8)
-        self.assertEqual(context["s3_request_concurrency"]["limit"], 8)
-        self.assertEqual(
-            context["experimental_s3_rate_limiter"]["read_rate"], 8
-        )
-        self.assertEqual(
-            context["experimental_s3_rate_limiter"]["write_rate"], 8
-        )
-
-    @patch("multiprocessing.cpu_count")
-    def test_create_spec_default_cpu_count(self, mock_cpu_count):
-        """Test that cpu_count defaults to multiprocessing.cpu_count()."""
-        mock_cpu_count.return_value = 16
-
-        spec = create_spec(
-            output_path="/test/path",
-            data_shape=[1, 1, 100, 200, 300],
-            data_dtype="uint16",
-            shard_shape=[1, 1, 50, 100, 150],
-            chunk_shape=[1, 1, 25, 50, 75],
-            zyx_resolution=[1.0, 0.5, 0.5],
-            compressor_kwargs={"cname": "zstd", "clevel": 5},
-            bucket_name="test-bucket",
-        )
-
-        context = spec["kvstore"]["context"]
-        self.assertEqual(context["data_copy_concurrency"]["limit"], 16)
-        mock_cpu_count.assert_called_once()
+        self.assertEqual(spec["kvstore"]["aws_credentials"]["type"], "default")
 
     def test_create_spec_resolution_formatting(self):
         """Test that zyx_resolution is properly formatted with units."""
@@ -115,6 +83,7 @@ class TestCreateSpec(unittest.TestCase):
             chunk_shape=[1, 1, 25, 50, 75],
             zyx_resolution=[2.0, 1.0, 1.0],
             compressor_kwargs={"cname": "zstd", "clevel": 5},
+            bucket_name="test-bucket",
         )
 
         expected_units = [None, None, "2.0um", "1.0um", "1.0um"]
@@ -122,217 +91,73 @@ class TestCreateSpec(unittest.TestCase):
             spec["metadata"]["attributes"]["dimension_units"], expected_units
         )
 
-    def test_create_spec_with_none_resolution(self):
-        """Test handling of None values in resolution."""
-        spec = create_spec(
-            output_path="/test/path",
-            data_shape=[1, 1, 100, 200, 300],
-            data_dtype="uint16",
-            shard_shape=[1, 1, 50, 100, 150],
-            chunk_shape=[1, 1, 25, 50, 75],
-            zyx_resolution=[None, 0.5, 0.5],
-            compressor_kwargs={"cname": "zstd", "clevel": 5},
-        )
 
-        expected_units = [None, None, None, "0.5um", "0.5um"]
-        self.assertEqual(
-            spec["metadata"]["attributes"]["dimension_units"], expected_units
-        )
-
-    def test_create_spec_custom_scale(self):
-        """Test create_spec with custom scale parameter."""
-        spec = create_spec(
-            output_path="/test/path",
-            data_shape=[1, 1, 100, 200, 300],
-            data_dtype="uint16",
-            shard_shape=[1, 1, 50, 100, 150],
-            chunk_shape=[1, 1, 25, 50, 75],
-            zyx_resolution=[1.0, 0.5, 0.5],
-            compressor_kwargs={"cname": "zstd", "clevel": 5},
-            scale="2",
-        )
-
-        self.assertEqual(spec["path"], "2")
-
-
-class TestCreateDownsampleDataset(unittest.IsolatedAsyncioTestCase):
+class TestCreateDownsampleDataset(unittest.TestCase):
     """Test cases for the create_downsample_dataset function."""
 
-    @patch("aind_hcr_data_transformation.compress.czi_to_zarr.create_spec")
-    @patch("tensorstore.open", new_callable=AsyncMock)
-    async def test_create_downsample_dataset_basic(
-        self, mock_ts_open, mock_create_spec
-    ):
+    @patch("aind_hcr_data_transformation.compress.czi_to_zarr_s3.create_spec")
+    @patch("aind_hcr_data_transformation.compress.czi_to_zarr_s3.ts.open")
+    def test_create_downsample_dataset_basic(self, mock_ts_open, mock_create_spec):
         """Test basic downsampling functionality."""
 
         mock_source_dataset = Mock()
         mock_source_dataset.dtype.name = "uint16"
-        mock_source_dataset.chunk_layout.write_chunk.shape = [
-            1,
-            1,
-            50,
-            100,
-            150,
-        ]
+        mock_source_dataset.chunk_layout.write_chunk.shape = [1, 1, 50, 100, 150]
         mock_source_dataset.chunk_layout.read_chunk.shape = [1, 1, 25, 50, 75]
 
         mock_downsampled_data = np.zeros((1, 1, 50, 100, 150), dtype=np.uint16)
 
         # Create a mock for the downsampled dataset
-        # (returned on first tensorstore.open call)
-        mock_downsampled_dataset = AsyncMock()
+        mock_downsampled_dataset = Mock()
         mock_downsampled_dataset.base = mock_source_dataset
         mock_downsampled_dataset.shape = [1, 1, 50, 100, 150]
-        mock_downsampled_dataset.dimension_units = [
-            None,
-            None,
-            "2.0um",
-            "1.0um",
-            "1.0um",
-        ]
-        mock_downsampled_dataset.read = AsyncMock(
-            return_value=mock_downsampled_data
-        )
+        mock_downsampled_dataset.dimension_units = [None, None, "2.0um", "1.0um", "1.0um"]
+        
+        # Mock result() method
+        mock_read_result = Mock()
+        mock_read_result.result.return_value = mock_downsampled_data
+        mock_downsampled_dataset.read.return_value = mock_read_result
 
-        mock_output_dataset = AsyncMock()
-        mock_output_dataset.write = AsyncMock(return_value=None)
+        mock_output_dataset = Mock()
+        mock_write_result = Mock()
+        mock_write_result.result.return_value = None
+        mock_transaction_dataset = Mock()
+        mock_transaction_dataset.write.return_value = mock_write_result
+        mock_output_dataset.with_transaction.return_value = mock_transaction_dataset
 
-        mock_ts_open.side_effect = [
-            mock_downsampled_dataset,
-            mock_output_dataset,
-        ]
+        # Mock the ts.open results
+        mock_open_result1 = Mock()
+        mock_open_result1.result.return_value = mock_downsampled_dataset
+        mock_open_result2 = Mock() 
+        mock_open_result2.result.return_value = mock_output_dataset
 
+        mock_ts_open.side_effect = [mock_open_result1, mock_open_result2]
         mock_create_spec.return_value = {"driver": "zarr"}
 
-        await create_downsample_dataset(
+        create_downsample_dataset(
             dataset_path="/test/dataset",
             start_scale=0,
             downsample_factor=[2, 2, 2],
             downsample_mode="mean",
             compressor_kwargs={"cname": "zstd", "clevel": 5},
-        )
-
-        self.assertEqual(mock_ts_open.call_count, 2)
-
-        # Check spec of first call (downsample)
-        downsample_spec_call = mock_ts_open.call_args_list[0][1]["spec"]
-        self.assertEqual(downsample_spec_call["driver"], "downsample")
-        self.assertEqual(
-            downsample_spec_call["downsample_factors"], [1, 1, 2, 2, 2]
-        )
-        self.assertEqual(downsample_spec_call["downsample_method"], "mean")
-
-        # Check create_spec was called with expected arguments
-        mock_create_spec.assert_called_once()
-        create_spec_args = mock_create_spec.call_args.kwargs
-        self.assertEqual(create_spec_args["output_path"], "/test/dataset")
-        self.assertEqual(create_spec_args["scale"], 1)  # start_scale + 1
-
-        # Ensure data was read and written
-        mock_downsampled_dataset.read.assert_awaited_once()
-        mock_output_dataset.write.assert_awaited_once_with(
-            mock_downsampled_data
-        )
-
-    @patch("multiprocessing.cpu_count", return_value=8)
-    @patch("aind_hcr_data_transformation.compress.czi_to_zarr.create_spec")
-    @patch("tensorstore.open", new_callable=AsyncMock)
-    async def test_create_downsample_dataset_with_s3(
-        self, mock_ts_open, mock_create_spec, mock_cpu_count
-    ):
-        """Test downsampling with S3 configuration."""
-
-        # Set up the source dataset
-        mock_source_dataset = Mock()
-        mock_source_dataset.dtype.name = "float32"
-        mock_source_dataset.chunk_layout.write_chunk.shape = [1, 1, 32, 64, 64]
-        mock_source_dataset.chunk_layout.read_chunk.shape = [1, 1, 16, 32, 32]
-
-        mock_downsampled_data = np.zeros((1, 1, 25, 50, 50), dtype=np.float32)
-
-        mock_downsampled_dataset = AsyncMock()
-        mock_downsampled_dataset.base = mock_source_dataset
-        mock_downsampled_dataset.shape = [1, 1, 25, 50, 50]
-        mock_downsampled_dataset.dimension_units = [
-            None,
-            None,
-            "4.0um",
-            "2.0um",
-            "2.0um",
-        ]
-        mock_downsampled_dataset.read = AsyncMock(
-            return_value=mock_downsampled_data
-        )
-
-        mock_output_dataset = AsyncMock()
-        mock_output_dataset.write = AsyncMock(return_value=None)
-
-        mock_ts_open.side_effect = [
-            mock_downsampled_dataset,
-            mock_output_dataset,
-        ]
-
-        mock_create_spec.return_value = {"driver": "zarr"}
-
-        await create_downsample_dataset(
-            dataset_path="/test/dataset",
-            start_scale=1,
-            downsample_factor=[2, 2, 2],
-            downsample_mode="median",
-            compressor_kwargs={"cname": "lz4"},
             bucket_name="test-bucket",
-            aws_region="eu-west-1",
-            read_cache_bytes=2**32,
         )
 
         self.assertEqual(mock_ts_open.call_count, 2)
-
-        downsample_spec = mock_ts_open.call_args_list[0][1]["spec"]
-        base_kvstore = downsample_spec["base"]["kvstore"]
-        self.assertEqual(base_kvstore["driver"], "s3")
-        self.assertEqual(base_kvstore["bucket"], "test-bucket")
-        self.assertEqual(base_kvstore["aws_region"], "eu-west-1")
-        self.assertEqual(
-            base_kvstore["context"]["cache_pool"]["total_bytes_limit"], 2**32
-        )
-
-        mock_downsampled_dataset.read.assert_awaited_once()
-        mock_output_dataset.write.assert_awaited_once_with(
-            mock_downsampled_data
-        )
-
         mock_create_spec.assert_called_once()
-        create_spec_args = mock_create_spec.call_args.kwargs
-        self.assertEqual(create_spec_args["output_path"], "/test/dataset")
-        self.assertEqual(create_spec_args["scale"], 2)  # start_scale + 1
 
-    @patch("aind_hcr_data_transformation.compress.czi_to_zarr.write_json")
-    @patch(
-        "aind_hcr_data_transformation.compress."
-        "czi_to_zarr.create_downsample_dataset",
-        new_callable=AsyncMock,
-    )
-    @patch(
-        "aind_hcr_data_transformation.compress." "czi_to_zarr.write_tasks",
-        new_callable=AsyncMock,
-    )
-    @patch("aind_hcr_data_transformation.compress." "czi_to_zarr.ts.open")
-    @patch(
-        "aind_hcr_data_transformation.compress."
-        "czi_to_zarr.czi_block_generator"
-    )
-    @patch("aind_hcr_data_transformation.compress." "czi_to_zarr.create_spec")
-    @patch(
-        "aind_hcr_data_transformation.compress."
-        "czi_to_zarr._get_pyramid_metadata"
-    )
-    @patch(
-        "aind_hcr_data_transformation.compress.czi_to_zarr"
-        ".write_ome_ngff_metadata"
-    )
-    @patch(
-        "aind_hcr_data_transformation.compress.czi_to_zarr" ".czifile.CziFile"
-    )
+
+class TestCziStackZarrWriter(unittest.TestCase):
+    """Test cases for the czi_stack_zarr_writer function."""
+
+    @patch("aind_hcr_data_transformation.compress.czi_to_zarr_s3.write_json")
+    @patch("aind_hcr_data_transformation.compress.czi_to_zarr_s3.create_downsample_dataset")
+    @patch("aind_hcr_data_transformation.compress.czi_to_zarr_s3.ts.open")
+    @patch("aind_hcr_data_transformation.compress.czi_to_zarr_s3.czi_block_generator")
+    @patch("aind_hcr_data_transformation.compress.czi_to_zarr_s3.create_spec")
+    @patch("aind_hcr_data_transformation.compress.czi_to_zarr_s3._get_pyramid_metadata")
+    @patch("aind_hcr_data_transformation.compress.czi_to_zarr_s3.write_ome_ngff_metadata")
+    @patch("aind_hcr_data_transformation.compress.czi_to_zarr_s3.czifile.CziFile")
     def test_czi_stack_zarr_writer(
         self,
         mock_czifile,
@@ -341,12 +166,10 @@ class TestCreateDownsampleDataset(unittest.IsolatedAsyncioTestCase):
         mock_create_spec,
         mock_czi_block_generator,
         mock_ts_open,
-        mock_write_tasks,
         mock_create_downsample_dataset,
         mock_write_json,
     ):
         """Test the czi_stack_zarr_writer function."""
-        mock_logger = Mock(spec=logging.Logger)
 
         mock_czi = MagicMock()
         mock_czi.__enter__.return_value = mock_czi
@@ -359,7 +182,12 @@ class TestCreateDownsampleDataset(unittest.IsolatedAsyncioTestCase):
         mock_czi_block_generator.return_value = [(fake_block, slice(0, 10))]
 
         mock_dataset = MagicMock()
-        mock_dataset.__getitem__.return_value.write.return_value = AsyncMock()
+        mock_transaction_dataset = Mock()
+        mock_write_result = Mock()
+        mock_write_result.result.return_value = None
+        mock_transaction_dataset.write.return_value = mock_write_result
+        mock_dataset.__getitem__.return_value.with_transaction.return_value = mock_transaction_dataset
+        
         mock_ts_result = MagicMock()
         mock_ts_result.result.return_value = mock_dataset
         mock_ts_open.return_value = mock_ts_result
@@ -378,21 +206,17 @@ class TestCreateDownsampleDataset(unittest.IsolatedAsyncioTestCase):
             scale_factor=[2, 2, 2],
             n_lvls=2,
             channel_name="DAPI",
-            logger=mock_logger,
             stack_name="my_stack",
             compressor_kwargs={"cname": "zstd"},
+            bucket_name="test-bucket",
             downsample_mode="mean",
-            batch_size=4,
-            bucket_name=None,
         )
 
         # Assertions
         mock_ts_open.assert_called()
         mock_create_spec.assert_called_once()
-        mock_write_tasks.assert_awaited_once()
-        self.assertEqual(mock_create_downsample_dataset.await_count, 2)
+        self.assertEqual(mock_create_downsample_dataset.call_count, 2)
         mock_write_json.assert_called_once()
-        mock_logger.info.assert_called()
 
 
 class TestHelpers(unittest.TestCase):
@@ -407,7 +231,6 @@ class TestHelpers(unittest.TestCase):
         }
         self.sample_data_shape = [1, 1, 100, 200, 300]
         self.sample_voxel_size = [2.0, 1.0, 1.0]
-        self.mock_logger = Mock(spec=logging.Logger)
 
     def test_sample_data_consistency(self):
         """Test that sample data is consistent."""


### PR DESCRIPTION
The simplest implementation of transactions without any multiprocessing or refactoring of block scheduler. 
Added:
 - transactions for czi_zstack_zarr_writer() and create_downsample_dataset()
 - a bit of error handling in czi_zstack_zarr_writer()
 - awscredentials "default" to kvstore init
 - mp "spawn" method for new processes. 