### PR TITLE
Fix chunking

### DIFF
--- a/src/aind_hcr_data_transformation/compress/czi_to_zarr_s3.py
+++ b/src/aind_hcr_data_transformation/compress/czi_to_zarr_s3.py
@@ -381,39 +381,71 @@ def czi_stack_zarr_writer(
         )
         dataset = ts.open(spec).result()
 
-        # shard size must be TCZYX order
-        block_count = 0
-        for block, axis_area in czi_block_generator(
+               # Align z block size to shard z extent for cleaner writes
+        shard_t, shard_c, shard_z, shard_y, shard_x = dataset.chunk_layout.write_chunk.shape
+        logging.info(f"Shard shape (t,c,z,y,x)={dataset.chunk_layout.write_chunk.shape}")
+        logging.info(f"Inner (codec) chunk shape (t,c,z,y,x)={dataset.chunk_layout.read_chunk.shape}")
+
+        # Ensure our generator uses shard_z as the jump so each block spans shard z (unless image smaller).
+        z_jump = shard_z
+
+        total_written_shards = 0
+        start_loop_time = time.time()
+
+        for z_block, axis_area in czi_block_generator(
             czi,
-            axis_jumps=shard_size[-3],
+            axis_jumps=z_jump,
             slice_axis="z",
         ):
-            region = (
-                slice(None),
-                slice(None),
-                axis_area,
-                slice(0, dataset_shape[-2]),
-                slice(0, dataset_shape[-1]),
-            )
-            try:
-                with ts.Transaction() as transaction:
-                    dataset[region].with_transaction(transaction).write(
-                        pad_array_n_d(block)
-                    ).result()
-                block_count += 1
-                logging.info(
-                    f"Completed block {block_count} write for z-slices {axis_area}"
-                )
-            except Exception as e:
-                logging.error(
-                    f"Failed to write block {block_count} for z-slices {axis_area}: {e}"
-                )
-                raise e
-            # dataset[region].write(pad_array_n_d(block)).result()
+            # Normalize to 5D (t,c,z,y,x)
+            z_block = pad_array_n_d(z_block)
 
-        # Waiting for the tensorstore tasks
-        # asyncio.run(write_tasks(tasks, batch_size=batch_size))
+            z_start = axis_area.start
+            z_stop = axis_area.stop   # exclusive
+            # We expect (z_stop - z_start) <= shard_z
+            local_z_span = z_stop - z_start
 
+            # Iterate over shard-aligned Y,X windows
+            for y0 in range(0, dataset_shape[-2], shard_y):
+                y1 = min(y0 + shard_y, dataset_shape[-2])
+                for x0 in range(0, dataset_shape[-1], shard_x):
+                    x1 = min(x0 + shard_x, dataset_shape[-1])
+
+                    # Region in dataset (t full, c full, full z span of this block, y segment, x segment)
+                    region = (
+                        slice(0, dataset_shape[0]),            # t
+                        slice(0, dataset_shape[1]),            # c
+                        slice(z_start, z_stop),                # z (<= shard_z)
+                        slice(y0, y1),
+                        slice(x0, x1),
+                    )
+
+                    # Extract matching subarray from z_block
+                    # z_block shape: (t,c,local_z_span,y,x)
+                    sub = z_block[..., 0:local_z_span, y0:y1, x0:x1]
+
+                    try:
+                        with ts.Transaction() as txn:
+                            dataset[region].with_transaction(txn).write(sub).result()
+                        total_written_shards += 1
+                        logging.debug(
+                            f"Committed shard-like write z[{z_start}:{z_stop}) "
+                            f"y[{y0}:{y1}) x[{x0}:{x1}) "
+                            f"({total_written_shards} writes so far)"
+                        )
+                    except Exception as e:
+                        logging.error(
+                            f"Failed writing region z[{z_start}:{z_stop}) "
+                            f"y[{y0}:{y1}) x[{x0}:{x1}) : {e}"
+                        )
+                        raise
+
+        logging.info(
+            f"Finished full-res aligned writes: {total_written_shards} shard-region writes "
+            f"in {time.time()-start_loop_time:.2f}s"
+        )
+
+        # Downsample pyramid creation
         for level in range(n_lvls):
             create_downsample_dataset(
                 dataset_path=output_path,
@@ -423,7 +455,7 @@ def czi_stack_zarr_writer(
                 compressor_kwargs=compressor_kwargs,
                 bucket_name=bucket_name,
             )
-
+            
     # Writes top level json
     write_json(
         bucket_name=bucket_name,
@@ -433,3 +465,5 @@ def czi_stack_zarr_writer(
 
     end_time = time.time()
     logging.info(f"Time to write the dataset: {end_time - start_time}")
+
+            ],

--- a/src/aind_hcr_data_transformation/compress/czi_to_zarr_s3.py
+++ b/src/aind_hcr_data_transformation/compress/czi_to_zarr_s3.py
@@ -93,7 +93,7 @@ def create_spec(
             "fill_value": 0,
             "chunk_grid": {
                 "name": "regular",
-                "configuration": {"chunk_shape": shard_shape},
+                "configuration": {"chunk_shape": chunk_shape},
             },
             "chunk_key_encoding": {
                 "name": "default",
@@ -455,7 +455,6 @@ def czi_stack_zarr_writer(
                 compressor_kwargs=compressor_kwargs,
                 bucket_name=bucket_name,
             )
-            
     # Writes top level json
     write_json(
         bucket_name=bucket_name,
@@ -465,5 +464,4 @@ def czi_stack_zarr_writer(
 
     end_time = time.time()
     logging.info(f"Time to write the dataset: {end_time - start_time}")
-
-            ],
+    return

--- a/src/aind_hcr_data_transformation/compress/czi_to_zarr_s3.py
+++ b/src/aind_hcr_data_transformation/compress/czi_to_zarr_s3.py
@@ -389,7 +389,7 @@ def czi_stack_zarr_writer(
         # Ensure our generator uses shard_z as the jump so each block spans shard z (unless image smaller).
         z_jump = shard_z
 
-        total_written_shards = 0
+        total_written_chunks = 0
         start_loop_time = time.time()
 
         for z_block, axis_area in czi_block_generator(
@@ -427,11 +427,11 @@ def czi_stack_zarr_writer(
                     try:
                         with ts.Transaction() as txn:
                             dataset[region].with_transaction(txn).write(sub).result()
-                        total_written_shards += 1
+                        total_written_chunks += 1
                         logging.debug(
-                            f"Committed shard-like write z[{z_start}:{z_stop}) "
+                            f"Committed chunk-like write z[{z_start}:{z_stop}) "
                             f"y[{y0}:{y1}) x[{x0}:{x1}) "
-                            f"({total_written_shards} writes so far)"
+                            f"({total_written_chunks} writes so far)"
                         )
                     except Exception as e:
                         logging.error(
@@ -441,7 +441,7 @@ def czi_stack_zarr_writer(
                         raise
 
         logging.info(
-            f"Finished full-res aligned writes: {total_written_shards} shard-region writes "
+            f"Finished full-res aligned writes: {total_written_chunks} chunk-region writes "
             f"in {time.time()-start_loop_time:.2f}s"
         )
 

--- a/src/aind_hcr_data_transformation/compress/czi_to_zarr_s3.py
+++ b/src/aind_hcr_data_transformation/compress/czi_to_zarr_s3.py
@@ -224,9 +224,11 @@ def create_downsample_dataset(
     down_dataset = ts.open(down_spec).result()
     try:
         with ts.Transaction() as transaction:
-            downsampled_data = downsampled_dataset.with_transaction(
-                transaction
-            ).read().result()
+            downsampled_data = (
+                downsampled_dataset.with_transaction(transaction)
+                .read()
+                .result()
+            )
     except Exception as e:
         logging.error(f"Failed to read downsampled data: {e}")
         raise e
@@ -239,6 +241,7 @@ def create_downsample_dataset(
     except Exception as e:
         logging.error(f"Failed to write downsample scale {new_scale}: {e}")
         raise e
+
 
 def czi_stack_zarr_writer(
     czi_path: str,
@@ -381,10 +384,20 @@ def czi_stack_zarr_writer(
         )
         dataset = ts.open(spec).result()
 
-               # Align z block size to shard z extent for cleaner writes
-        shard_t, shard_c, shard_z, shard_y, shard_x = dataset.chunk_layout.write_chunk.shape
-        logging.info(f"Shard shape (t,c,z,y,x)={dataset.chunk_layout.write_chunk.shape}")
-        logging.info(f"Inner (codec) chunk shape (t,c,z,y,x)={dataset.chunk_layout.read_chunk.shape}")
+        # Align z block size to shard z extent for cleaner writes
+        (
+            shard_t,
+            shard_c,
+            shard_z,
+            shard_y,
+            shard_x,
+        ) = dataset.chunk_layout.write_chunk.shape
+        logging.info(
+            f"Shard shape (t,c,z,y,x)={dataset.chunk_layout.write_chunk.shape}"
+        )
+        logging.info(
+            f"Inner (codec) chunk shape (t,c,z,y,x)={dataset.chunk_layout.read_chunk.shape}"
+        )
 
         # Ensure our generator uses shard_z as the jump so each block spans shard z (unless image smaller).
         z_jump = shard_z
@@ -401,7 +414,7 @@ def czi_stack_zarr_writer(
             z_block = pad_array_n_d(z_block)
 
             z_start = axis_area.start
-            z_stop = axis_area.stop   # exclusive
+            z_stop = axis_area.stop  # exclusive
             # We expect (z_stop - z_start) <= shard_z
             local_z_span = z_stop - z_start
 
@@ -413,9 +426,9 @@ def czi_stack_zarr_writer(
 
                     # Region in dataset (t full, c full, full z span of this block, y segment, x segment)
                     region = (
-                        slice(0, dataset_shape[0]),            # t
-                        slice(0, dataset_shape[1]),            # c
-                        slice(z_start, z_stop),                # z (<= shard_z)
+                        slice(0, dataset_shape[0]),  # t
+                        slice(0, dataset_shape[1]),  # c
+                        slice(z_start, z_stop),  # z (<= shard_z)
                         slice(y0, y1),
                         slice(x0, x1),
                     )
@@ -426,7 +439,9 @@ def czi_stack_zarr_writer(
 
                     try:
                         with ts.Transaction() as txn:
-                            dataset[region].with_transaction(txn).write(sub).result()
+                            dataset[region].with_transaction(txn).write(
+                                sub
+                            ).result()
                         total_written_chunks += 1
                         logging.debug(
                             f"Committed chunk-like write z[{z_start}:{z_stop}) "

--- a/tests/test_compress/test_czi_to_zarr.py
+++ b/tests/test_compress/test_czi_to_zarr.py
@@ -97,12 +97,20 @@ class TestCreateDownsampleDataset(unittest.TestCase):
 
     @patch("aind_hcr_data_transformation.compress.czi_to_zarr_s3.create_spec")
     @patch("aind_hcr_data_transformation.compress.czi_to_zarr_s3.ts.open")
-    def test_create_downsample_dataset_basic(self, mock_ts_open, mock_create_spec):
+    def test_create_downsample_dataset_basic(
+        self, mock_ts_open, mock_create_spec
+    ):
         """Test basic downsampling functionality."""
 
         mock_source_dataset = Mock()
         mock_source_dataset.dtype.name = "uint16"
-        mock_source_dataset.chunk_layout.write_chunk.shape = [1, 1, 50, 100, 150]
+        mock_source_dataset.chunk_layout.write_chunk.shape = [
+            1,
+            1,
+            50,
+            100,
+            150,
+        ]
         mock_source_dataset.chunk_layout.read_chunk.shape = [1, 1, 25, 50, 75]
 
         mock_downsampled_data = np.zeros((1, 1, 50, 100, 150), dtype=np.uint16)
@@ -111,8 +119,14 @@ class TestCreateDownsampleDataset(unittest.TestCase):
         mock_downsampled_dataset = Mock()
         mock_downsampled_dataset.base = mock_source_dataset
         mock_downsampled_dataset.shape = [1, 1, 50, 100, 150]
-        mock_downsampled_dataset.dimension_units = [None, None, "2.0um", "1.0um", "1.0um"]
-        
+        mock_downsampled_dataset.dimension_units = [
+            None,
+            None,
+            "2.0um",
+            "1.0um",
+            "1.0um",
+        ]
+
         # Mock result() method
         mock_read_result = Mock()
         mock_read_result.result.return_value = mock_downsampled_data
@@ -123,12 +137,14 @@ class TestCreateDownsampleDataset(unittest.TestCase):
         mock_write_result.result.return_value = None
         mock_transaction_dataset = Mock()
         mock_transaction_dataset.write.return_value = mock_write_result
-        mock_output_dataset.with_transaction.return_value = mock_transaction_dataset
+        mock_output_dataset.with_transaction.return_value = (
+            mock_transaction_dataset
+        )
 
         # Mock the ts.open results
         mock_open_result1 = Mock()
         mock_open_result1.result.return_value = mock_downsampled_dataset
-        mock_open_result2 = Mock() 
+        mock_open_result2 = Mock()
         mock_open_result2.result.return_value = mock_output_dataset
 
         mock_ts_open.side_effect = [mock_open_result1, mock_open_result2]
@@ -151,13 +167,23 @@ class TestCziStackZarrWriter(unittest.TestCase):
     """Test cases for the czi_stack_zarr_writer function."""
 
     @patch("aind_hcr_data_transformation.compress.czi_to_zarr_s3.write_json")
-    @patch("aind_hcr_data_transformation.compress.czi_to_zarr_s3.create_downsample_dataset")
+    @patch(
+        "aind_hcr_data_transformation.compress.czi_to_zarr_s3.create_downsample_dataset"
+    )
     @patch("aind_hcr_data_transformation.compress.czi_to_zarr_s3.ts.open")
-    @patch("aind_hcr_data_transformation.compress.czi_to_zarr_s3.czi_block_generator")
+    @patch(
+        "aind_hcr_data_transformation.compress.czi_to_zarr_s3.czi_block_generator"
+    )
     @patch("aind_hcr_data_transformation.compress.czi_to_zarr_s3.create_spec")
-    @patch("aind_hcr_data_transformation.compress.czi_to_zarr_s3._get_pyramid_metadata")
-    @patch("aind_hcr_data_transformation.compress.czi_to_zarr_s3.write_ome_ngff_metadata")
-    @patch("aind_hcr_data_transformation.compress.czi_to_zarr_s3.czifile.CziFile")
+    @patch(
+        "aind_hcr_data_transformation.compress.czi_to_zarr_s3._get_pyramid_metadata"
+    )
+    @patch(
+        "aind_hcr_data_transformation.compress.czi_to_zarr_s3.write_ome_ngff_metadata"
+    )
+    @patch(
+        "aind_hcr_data_transformation.compress.czi_to_zarr_s3.czifile.CziFile"
+    )
     def test_czi_stack_zarr_writer(
         self,
         mock_czifile,
@@ -186,8 +212,10 @@ class TestCziStackZarrWriter(unittest.TestCase):
         mock_write_result = Mock()
         mock_write_result.result.return_value = None
         mock_transaction_dataset.write.return_value = mock_write_result
-        mock_dataset.__getitem__.return_value.with_transaction.return_value = mock_transaction_dataset
-        
+        mock_dataset.__getitem__.return_value.with_transaction.return_value = (
+            mock_transaction_dataset
+        )
+
         mock_ts_result = MagicMock()
         mock_ts_result.result.return_value = mock_dataset
         mock_ts_open.return_value = mock_ts_result

--- a/tests/test_utils/test_utils.py
+++ b/tests/test_utils/test_utils.py
@@ -226,7 +226,6 @@ class TestReadSlicesCzi(unittest.TestCase):
                 "concurrent.futures.ThreadPoolExecutor"
             ) as mock_executor_class,
         ):
-
             mock_squeeze.return_value = "squeezed_result"
             mock_executor_class.return_value.__enter__.return_value = (
                 mock_executor
@@ -290,7 +289,6 @@ class TestReadSlicesCzi(unittest.TestCase):
                 "aind_hcr_data_transformation.utils.utils.ThreadPoolExecutor"
             ) as mock_executor_class,
         ):
-
             mock_squeeze.return_value = "squeezed_result"
             mock_executor = Mock()
             mock_executor_class.return_value.__enter__.return_value = (
@@ -349,7 +347,6 @@ class TestReadSlicesCzi(unittest.TestCase):
                 side_effect=track_parallel_creation,
             ),
         ):
-
             mock_squeeze.return_value = "squeezed_result"
 
             utils.read_slices_czi(


### PR DESCRIPTION
Write only a single chunk at a time in tensorstore transactions at the top - level in czi_stack_zarr_writer(). 
This might be a bit slower by only reading 128 z planes at a time from the czi file, but currently untested. 